### PR TITLE
Add confirmation time

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -276,8 +276,6 @@ function get_post_type_label_singular( $post_id ) {
 			</small></p>
 		<?php endif; ?>
 
-		<?php wp_nonce_url( $actionurl, $action, $name ); ?>
-
 		<div class="hm-confirm-as-read-confirmed-users">
 			<h4><span class="hm-car-icon-tick">✔</span> <?php echo esc_html( $settings['confirmed_text'] ); ?></h4>
 			<?php render_confirmed_users( $post_id ); ?>
@@ -327,8 +325,9 @@ function render_unconfirmed_users( $post_id ) {
 		}
 		echo '</ul>';
 	} else {
+		$settings = Settings\get_settings();
 		echo '<p>';
-		echo esc_html( $settings['none_confirmed_text'] );
+		echo esc_html( $settings['none_unconfirmed_text'] );
 		echo '</p>';
 	}
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -323,11 +323,14 @@ function get_post_type_label_singular( $post_id ) {
  * @return void
  */
 function render_confirmed_users( $post_id ) {
-	if ( $users = get_confirmed_users_for_post( $post_id ) ) {
-		$users = get_users( [ 'include' => $users ] );
+	$confirmations = get_confirmed_users( $post_id );
+	$ids = array_keys( $confirmations );
+	if ( $ids ) {
+		$users = get_users( [ 'include' => $ids ] );
 		echo '<ul class="hm-car-users">';
 		foreach ( $users as $user ) {
-			render_user_list_item( $user );
+			$confirmed_at = $confirmations[ $user->ID ] ?? null;
+			render_user_list_item( $user, $confirmed_at );
 		}
 		echo '</ul>';
 	} else {
@@ -368,11 +371,21 @@ function render_unconfirmed_users( $post_id ) {
  * @param  WP_User $user WP User object.
  * @return void
  */
-function render_user_list_item( $user ) {
+function render_user_list_item( $user, $confirmed_at = null ) {
 	?>
 	<li class="hm-car-user" tabindex="0">
 		<span class="hm-car-user-name"><?php echo esc_html( $user->display_name ); ?></span>
 		<?php echo get_avatar( $user->ID, 40 ); ?>
+		<span class="hm-car-user-confirmed-at">
+			<?php
+			if ( $confirmed_at ) {
+				printf(
+					'<time>' . _x( 'Confirmed at %s', 'print view confirmation date', 'hm-confirm-as-read' ) . '</time>',
+					esc_html( date( 'Y-m-d H:i:s', $confirmed_at ) )
+				);
+			}
+			?>
+		</span>
 	</li>
 	<?php
 }
@@ -470,6 +483,10 @@ function render_styles() {
 		display: block;
 	}
 
+	.hm-car-user-confirmed-at {
+		display: none;
+	}
+
 	.hm-car-icon-tick,
 	.hm-car-icon-cross {
 		color: #7DBF67;
@@ -484,6 +501,31 @@ function render_styles() {
 		padding: 5px 15px;
 		background: #E3EDDF;
 		border-radius: 2px;
+	}
+
+	@media print {
+		.hm-car-users {
+			display: table;
+		}
+		.hm-car-user {
+			float: none;
+			width: 100%;
+			display: table-row;
+		}
+		.hm-car-user img {
+			display: none;
+		}
+		.hm-car-user-name {
+			all: unset;
+			display: table-cell;
+			padding-right: 1em;
+		}
+		.hm-car-user-name:after {
+			display: none;
+		}
+		.hm-car-user-confirmed-at {
+			display: table-cell;
+		}
 	}
 	</style>
 	<?php

--- a/inc/settings/namespace.php
+++ b/inc/settings/namespace.php
@@ -93,7 +93,7 @@ function get_keys() {
  * @return array settings.
  */
 function get_settings( $raw = false ) {
-	$settings = get_option( 'hm_confirm_as_read_settings' );
+	$settings = get_option( 'hm_confirm_as_read_settings', [] );
 	if ( $raw ) {
 		$settings = wp_parse_args( $settings, array_map( '__return_empty_string', array_flip( get_keys() ) ) );
 	} else {


### PR DESCRIPTION
Stores a confirmation time when a user confirms for auditability. Additionally, adds a print style sheet which displays names and timestamps rather than avatars.

![Screenshot 2025-04-16 at 14 32 50](https://github.com/user-attachments/assets/6574bc91-3cbc-461c-a27c-ce0d9380fb34)

(Also fixed a couple other errors while I was in there.)